### PR TITLE
handle CRLF line terminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,10 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 
 - Added keyword auto-complete
 - Refactor of autocompletion system
+
+
+## [0.4.2] 
+
+### Fixed
+
+- Fixed incorrect error reporting locations on windows due to incorrect handling of CRLF line terminators see [issue #6](https://github.com/unfinishedprogram/wgsl-analyzer/issues/6)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wgsl-lang",
   "displayName": "WGSL Language Support",
   "description": "",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "noah-labrecque",
   "repository": {
     "type": "github",


### PR DESCRIPTION
This should fix #6 by correctly accounting for the extra size of CRLF line-terminators when converting between internal and LSP text-range types.