### PR TITLE
[0.6.0]: Code Formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,13 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 - Improved robustness and automation of releases
 
 
-## [0.6.1]
+## [0.6.0]
 
 ### Added
 
 - Code formatting for WGSL source files
   - Formatting style is inspired by rustfmt
+
+### Changed
+
+- Removed non-existent literals from language-configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,3 +94,11 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 - Updated Naga version to 24
 - Adjustments to diagnostic messages
 - Autocompletion is now more context aware
+
+
+
+## [0.5.1]
+
+### Changed
+
+- Improved robustness and automation of releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,3 +102,11 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 ### Changed
 
 - Improved robustness and automation of releases
+
+
+## [0.6.1]
+
+### Added
+
+- Code formatting for WGSL source files
+  - Formatting style is inspired by rustfmt

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # WGSL-Analyzer
 
-> A VSCode extension providing validation and syntax highlighting of WGSL (Web GPU Shading Language) files
+> A VSCode extension providing validation syntax highlighting and formatting of WGSL (Web GPU Shading Language) files
 
 *If you encounter any issues, please report them on [github](https://github.com/unfinishedprogram/wgsl-analyzer/issues)*
 
 ## Features
 
 - ✅ **Syntax highlighting of WGSL files**
+- ✅ **Code formatting**
 - ✅ **Syntax validation**
 - ✅ **Correctness validation**
 - ✅ **Document outline**
@@ -26,7 +27,7 @@
 
 ## About
 
-This extension is written in rust and uses Naga compiled to wasm to generate diagnostics. 
+This extension is written in rust and uses Naga compiled to wasm to generate diagnostics.
 This means that the extension should work on any platform, and does not require any external binaries.
 
 ## Developing

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,30 +1,26 @@
 {
-    "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
-    },
-    // symbols used as brackets
-    "brackets": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"]
-    ],
-    // symbols that are auto closed when typing
-    "autoClosingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
-    ],
-    // symbols that can be used to surround a selection
-    "surroundingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
-    ]
+  "comments": {
+    // symbol used for single line comment. Remove this entry if your language does not support line comments
+    "lineComment": "//",
+    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+    "blockComment": ["/*", "*/"]
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wgsl-lang",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wgsl-lang",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "vscode-languageclient": "^8.1.0",
         "vscode-languageserver": "^8.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wgsl-lang",
   "displayName": "WGSL Language Support",
   "description": "",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "publisher": "noah-labrecque",
   "repository": {
     "type": "github",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,15 @@ connection.onCompletion((...args) => JSON.parse(wgsl_ls.onCompletion(args[0])));
 
 connection.onDocumentSymbol((arg) => JSON.parse(wgsl_ls.onDocumentSymbol(arg)));
 
+connection.onDocumentFormatting((arg) => {
+  let res = wgsl_ls.onDocumentFormatting(JSON.stringify(arg));
+  if (res == undefined) {
+    return res;
+  } else {
+    return JSON.parse(res);
+  }
+});
+
 connection.onInitialize(() => {
   return {
     capabilities: {
@@ -32,6 +41,7 @@ connection.onInitialize(() => {
       completionProvider: {
         triggerCharacters: ["."],
       },
+      documentFormattingProvider: true,
       documentSymbolProvider: true,
       workspace: {
         workspaceFolders: { supported: true },

--- a/wgsl-language-server/Cargo.lock
+++ b/wgsl-language-server/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,10 +160,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "logos"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6f536c1af4c7cc81edf73da1f8029896e7e1e16a219ef09b184e76a296f3db"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189bbfd0b61330abea797e5e9276408f2edbe4f822d7ad08685d67419aafb34e"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "lsp-types"
@@ -253,6 +305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +324,12 @@ name = "ryu"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -464,6 +531,7 @@ dependencies = [
  "console_error_panic_hook",
  "either",
  "js-sys",
+ "logos",
  "lsp-types",
  "naga",
  "regex",

--- a/wgsl-language-server/Cargo.toml
+++ b/wgsl-language-server/Cargo.toml
@@ -11,6 +11,7 @@ codespan-reporting = "0.11.1"
 console_error_panic_hook = "0.1.6"
 either = "1.13.0"
 js-sys = "0.3.53"
+logos = "0.15.0"
 lsp-types = "0.97.0"
 naga = { version = "24.0.0", features = ["wgsl-in"] }
 regex = "1.9.3"

--- a/wgsl-language-server/src/document_tracker.rs
+++ b/wgsl-language-server/src/document_tracker.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, u32};
 
 use lsp_types::{
-    CompletionItem, DidChangeTextDocumentParams, DocumentSymbol, Position,
-    PublishDiagnosticsParams, TextDocumentItem, Uri,
+    CompletionItem, DidChangeTextDocumentParams, DocumentFormattingParams, DocumentSymbol,
+    Position, PublishDiagnosticsParams, Range, TextDocumentItem, TextEdit, Uri,
 };
 use naga::{
     front::wgsl::ParseError,
@@ -12,6 +12,7 @@ use naga::{
 
 use crate::{
     completions::CompletionProvider,
+    fmt,
     pretty_error::error_context::ModuleContext,
     range_tools::string_range,
     symbol_provider::SymbolProvider,
@@ -148,5 +149,15 @@ impl DocumentTracker {
             .values()
             .flat_map(|doc| doc.get_symbols())
             .collect()
+    }
+
+    pub fn format_document(&self, params: DocumentFormattingParams) -> Option<Vec<TextEdit>> {
+        let document = self.documents.get(&params.text_document.uri)?;
+        let result = fmt::print_ast(&document.content);
+
+        Some(vec![TextEdit::new(
+            Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
+            result,
+        )])
     }
 }

--- a/wgsl-language-server/src/document_tracker.rs
+++ b/wgsl-language-server/src/document_tracker.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, u32};
+use std::collections::HashMap;
 
 use lsp_types::{
     CompletionItem, DidChangeTextDocumentParams, DocumentFormattingParams, DocumentSymbol,
@@ -153,7 +153,7 @@ impl DocumentTracker {
 
     pub fn format_document(&self, params: DocumentFormattingParams) -> Option<Vec<TextEdit>> {
         let document = self.documents.get(&params.text_document.uri)?;
-        let result = fmt::print_ast(&document.content);
+        let result = fmt::pretty_print_ast(&document.content, &params.options)?;
 
         Some(vec![TextEdit::new(
             Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -1,3 +1,134 @@
-pub fn print_ast(code: &str) -> String {
-    code.to_string()
+use lsp_types::FormattingOptions;
+
+use crate::lexer::{lex, Token};
+
+pub fn indent_string(options: &FormattingOptions) -> String {
+    if options.insert_spaces {
+        " ".repeat(options.tab_size as usize)
+    } else {
+        "\t".to_string()
+    }
+}
+
+pub enum Delimiter {
+    DoubleNewline,
+    Newline,
+    Space,
+    None,
+}
+
+pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<String> {
+    let tokens = lex(code)?;
+
+    let mut formatted = String::new();
+    let mut indent_level: usize = 0;
+    let indent_str = indent_string(options);
+
+    for window in tokens.windows(2) {
+        let (token, span) = &window[0];
+        let (next_token, next_span) = &window[1];
+        let src_content = &code[span.clone()].trim();
+
+        // Whitespace will be anything skipped by the lexer
+        let whitespace_span = span.end..next_span.start;
+        let whitespace = &code[whitespace_span.clone()];
+
+        let whitespace_lines = whitespace.chars().filter(|it| *it == '\n').count();
+        let has_explicit_newline = if matches!(token, Token::Trivia(_)) {
+            // The trialing newline of comments is part of the token
+            // For the purposes of explicit newlines, we want to count it
+            whitespace_lines > 0
+        } else {
+            whitespace_lines > 1
+        };
+
+        use Delimiter as D;
+        use Token as T;
+
+        let delimiter = match (token, next_token) {
+            // Skip the delimiter for property access
+            (_, T::Syntax(".")) | (T::Syntax("."), _) => D::None,
+
+            (T::TemplateArgsStart, _) => D::None,
+            (_, T::TemplateArgsEnd) => D::None,
+
+            (T::Keyword(_) | T::Ident(_), T::TemplateArgsStart) => D::None,
+
+            (T::Syntax("("), _) => D::None,
+            (_, T::Syntax(")")) => D::None,
+
+            (T::Syntax(";"), T::Syntax("}")) => {
+                indent_level = indent_level.saturating_sub(1);
+                D::Newline
+            }
+            (T::Syntax(";"), _) => D::Newline,
+            (T::Syntax("{"), _) => {
+                indent_level += 1;
+                D::Newline
+            }
+            (_, T::Syntax("}")) => {
+                indent_level = indent_level.saturating_sub(1);
+                D::Newline
+            }
+            (T::Syntax("}"), _) => {
+                if indent_level == 0 {
+                    D::DoubleNewline
+                } else {
+                    D::Newline
+                }
+            }
+            (T::Syntax("@"), _) => D::None,
+            (_, T::Syntax(";")) => D::None,
+            (_, T::Syntax(",")) => D::None,
+            (T::Ident(_), T::Syntax(":")) => D::None,
+            (T::Ident(_), T::Syntax("(")) => D::None,
+            (T::Trivia(_), _) => D::Newline,
+            (
+                T::Keyword(_)
+                | T::Boolean(_)
+                | T::Ident(_)
+                | T::Integer(_)
+                | T::Float(_)
+                | T::Syntax(_)
+                | T::TemplateArgsEnd,
+                _,
+            ) => D::Space,
+        };
+
+        formatted.push_str(src_content);
+
+        match delimiter {
+            D::Newline => {
+                formatted.push('\n');
+                if has_explicit_newline {
+                    formatted.push('\n');
+                }
+                formatted.push_str(&indent_str.repeat(indent_level));
+            }
+            D::DoubleNewline => formatted.push_str("\n\n"),
+            D::Space => formatted.push(' '),
+            D::None => {}
+        }
+    }
+
+    let last_token = tokens.last()?;
+    formatted.push_str(&code[last_token.1.clone()]);
+
+    // Handle trailing whitespace
+    let trailing_whitespace = &code[last_token.1.end..code.len()];
+    let mut trailing_lines = trailing_whitespace.chars().filter(|it| *it == '\n').count();
+
+    if matches!(options.trim_final_newlines, Some(true)) {
+        trailing_lines = 0;
+    }
+
+    if matches!(options.insert_final_newline, Some(true)) {
+        trailing_lines = trailing_lines.min(1);
+    }
+
+    for _ in 0..trailing_lines {
+        formatted.push('\n');
+    }
+
+    Some(formatted)
 }

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -1,0 +1,3 @@
+pub fn print_ast(code: &str) -> String {
+    code.to_string()
+}

--- a/wgsl-language-server/src/lexer.rs
+++ b/wgsl-language-server/src/lexer.rs
@@ -1,0 +1,130 @@
+use comment::lex_multiline_comment;
+use logos::Logos;
+mod comment;
+mod keyword;
+mod test;
+use keyword::{parse_ident, IdentError, Keyword};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum LexError {
+    InvalidIdentifier(IdentError),
+    UnterminatedComment,
+    #[default]
+    Other,
+}
+
+impl From<IdentError> for LexError {
+    fn from(err: IdentError) -> Self {
+        LexError::InvalidIdentifier(err)
+    }
+}
+
+#[derive(Logos, Debug, PartialEq, Eq, Clone)]
+#[logos(error = LexError)]
+#[logos(skip r"\s")]
+pub enum Token<'src> {
+    #[token("alias", |_| Keyword::Alias)]
+    #[token("break", |_| Keyword::Break)]
+    #[token("case", |_| Keyword::Case)]
+    #[token("const", |_| Keyword::Const)]
+    #[token("const_assert", |_| Keyword::ConstAssert)]
+    #[token("continue", |_| Keyword::Continue)]
+    #[token("continuing", |_| Keyword::Continuing)]
+    #[token("default", |_| Keyword::Default)]
+    #[token("diagnostic", |_| Keyword::Diagnostic)]
+    #[token("discard", |_| Keyword::Discard)]
+    #[token("else", |_| Keyword::Else)]
+    #[token("enable", |_| Keyword::Enable)]
+    #[token("fn", |_| Keyword::Fn)]
+    #[token("for", |_| Keyword::For)]
+    #[token("if", |_| Keyword::If)]
+    #[token("let", |_| Keyword::Let)]
+    #[token("loop", |_| Keyword::Loop)]
+    #[token("override", |_| Keyword::Override)]
+    #[token("requires", |_| Keyword::Requires)]
+    #[token("return", |_| Keyword::Return)]
+    #[token("struct", |_| Keyword::Struct)]
+    #[token("switch", |_| Keyword::Switch)]
+    #[token("var", |_| Keyword::Var)]
+    #[token("while", |_| Keyword::While)]
+    Keyword(Keyword),
+
+    #[token("<<=")]
+    #[token(">>=")]
+    #[token("==")]
+    #[token("!=")]
+    #[token("<=")]
+    #[token(">=")]
+    #[token("&&")]
+    #[token("||")]
+    #[token("->")]
+    #[token("=>")]
+    #[token("++")]
+    #[token("--")]
+    #[token("+=")]
+    #[token("-=")]
+    #[token("*=")]
+    #[token("/=")]
+    #[token("%=")]
+    #[token("&=")]
+    #[token("|=")]
+    #[token("^=")]
+    #[token(">>")]
+    #[token("<<")]
+    #[token("(")]
+    #[token(")")]
+    #[token("[")]
+    #[token("]")]
+    #[token("{")]
+    #[token("}")]
+    #[token(";")]
+    #[token(".")]
+    #[token(",")]
+    #[token(":")]
+    #[token("&")]
+    #[token("|")]
+    #[token("^")]
+    #[token("@")]
+    #[token("=")]
+    #[token(">")]
+    #[token("<")]
+    #[token("%")]
+    #[token("/")]
+    #[token("+")]
+    #[token("-")]
+    #[token("*")]
+    #[token("~")]
+    #[token("!")]
+    Syntax(&'src str),
+
+    #[token("true", |_| true)]
+    #[token("false", |_| false)]
+    Boolean(bool),
+
+    #[regex(r"([_\p{XID_Start}][\p{XID_Continue}]+)|([\p{XID_Start}])|_", |lex| parse_ident(lex.slice()), priority = 2)]
+    Ident(&'src str),
+
+    #[regex(r"0[iu]?")] // Zero Values
+    #[regex(r"[1-9][0-9]*[iu]?")] // Decimal Literals
+    #[regex(r"0[xX][0-9a-fA-F]+[iu]?")] // Hex Literals
+    Integer(&'src str),
+
+    // Decimal Float Literals
+    #[regex(r"0[fh]")]
+    #[regex(r"[1-9][0-9]*[fh]")]
+    #[regex(r"[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?")]
+    #[regex(r"[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?", priority = 5)]
+    #[regex(r"[0-9]+[eE][+-]?[0-9]+[fh]?")]
+    // Hex Float Literals
+    #[regex(
+        r"0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9]+[fh]?)?",
+        priority = 9
+    )]
+    #[regex(r"0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP][+-]?[0-9]+[fh]?)?")]
+    #[regex(r"0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+[fh]?")]
+    Float(&'src str),
+
+    #[regex(r"/\*", lex_multiline_comment)]
+    #[regex(r"\/\/.*\n")]
+    Trivia(&'src str),
+}

--- a/wgsl-language-server/src/lexer/comment.rs
+++ b/wgsl-language-server/src/lexer/comment.rs
@@ -1,0 +1,40 @@
+use logos::Lexer;
+
+use super::{LexError, Token};
+
+pub fn lex_multiline_comment<'a>(lex: &mut Lexer<'a, Token<'a>>) -> Result<&'a str, LexError> {
+    let remainder_slice = lex.remainder();
+    let mut comment_depth = 1;
+    let mut pos = 0;
+
+    loop {
+        let next_comment_start = remainder_slice[pos..].find("/*");
+        let next_comment_end = remainder_slice[pos..].find("*/");
+        match (next_comment_start, next_comment_end) {
+            (Some(start), Some(end)) => {
+                if start < end {
+                    comment_depth += 1;
+                    pos += start + 2;
+                } else {
+                    comment_depth -= 1;
+                    pos += end + 2;
+                }
+            }
+            (Some(start), None) => {
+                pos += start + 2;
+            }
+            (None, Some(end)) => {
+                comment_depth -= 1;
+                pos += end + 2;
+                if comment_depth == 0 {
+                    lex.bump(pos);
+                    return Ok(lex.slice());
+                }
+            }
+            (None, None) => {
+                lex.bump(remainder_slice.len());
+                return Err(LexError::UnterminatedComment);
+            }
+        }
+    }
+}

--- a/wgsl-language-server/src/lexer/keyword.rs
+++ b/wgsl-language-server/src/lexer/keyword.rs
@@ -1,0 +1,203 @@
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum IdentError {
+    #[default]
+    Unknown,
+    SingleUnderscore,
+    DoubleLeadingUnderscore,
+    ReservedKeyword,
+}
+
+pub fn parse_ident(ident: &str) -> Result<&str, IdentError> {
+    if ident.starts_with("__") {
+        return Err(IdentError::DoubleLeadingUnderscore);
+    }
+
+    if ident == "_" {
+        return Err(IdentError::SingleUnderscore);
+    }
+
+    if is_reserved_word(ident) {
+        return Err(IdentError::ReservedKeyword);
+    }
+
+    Ok(ident)
+}
+
+fn is_reserved_word(ident: &str) -> bool {
+    matches!(
+        ident,
+        "NULL"
+            | "Self"
+            | "abstract"
+            | "active"
+            | "alignas"
+            | "alignof"
+            | "as"
+            | "asm"
+            | "asm_fragment"
+            | "async"
+            | "attribute"
+            | "auto"
+            | "await"
+            | "become"
+            | "binding_array"
+            | "cast"
+            | "catch"
+            | "class"
+            | "co_await"
+            | "co_return"
+            | "co_yield"
+            | "coherent"
+            | "column_major"
+            | "common"
+            | "compile"
+            | "compile_fragment"
+            | "concept"
+            | "const_cast"
+            | "consteval"
+            | "constexpr"
+            | "constinit"
+            | "crate"
+            | "debugger"
+            | "decltype"
+            | "delete"
+            | "demote"
+            | "demote_to_helper"
+            | "do"
+            | "dynamic_cast"
+            | "enum"
+            | "explicit"
+            | "export"
+            | "extends"
+            | "extern"
+            | "external"
+            | "fallthrough"
+            | "filter"
+            | "final"
+            | "finally"
+            | "friend"
+            | "from"
+            | "fxgroup"
+            | "get"
+            | "goto"
+            | "groupshared"
+            | "highp"
+            | "impl"
+            | "implements"
+            | "import"
+            | "inline"
+            | "instanceof"
+            | "interface"
+            | "layout"
+            | "lowp"
+            | "macro"
+            | "macro_rules"
+            | "match"
+            | "mediump"
+            | "meta"
+            | "mod"
+            | "module"
+            | "move"
+            | "mut"
+            | "mutable"
+            | "namespace"
+            | "new"
+            | "nil"
+            | "noexcept"
+            | "noinline"
+            | "nointerpolation"
+            | "noperspective"
+            | "null"
+            | "nullptr"
+            | "of"
+            | "operator"
+            | "package"
+            | "packoffset"
+            | "partition"
+            | "pass"
+            | "patch"
+            | "pixelfragment"
+            | "precise"
+            | "precision"
+            | "premerge"
+            | "priv"
+            | "protected"
+            | "pub"
+            | "public"
+            | "readonly"
+            | "ref"
+            | "regardless"
+            | "register"
+            | "reinterpret_cast"
+            | "require"
+            | "resource"
+            | "restrict"
+            | "self"
+            | "set"
+            | "shared"
+            | "sizeof"
+            | "smooth"
+            | "snorm"
+            | "static"
+            | "static_assert"
+            | "static_cast"
+            | "std"
+            | "subroutine"
+            | "super"
+            | "target"
+            | "template"
+            | "this"
+            | "thread_local"
+            | "throw"
+            | "trait"
+            | "try"
+            | "type"
+            | "typedef"
+            | "typeid"
+            | "typename"
+            | "typeof"
+            | "union"
+            | "unless"
+            | "unorm"
+            | "unsafe"
+            | "unsized"
+            | "use"
+            | "using"
+            | "varying"
+            | "virtual"
+            | "volatile"
+            | "wgsl"
+            | "where"
+            | "with"
+            | "writeonly"
+            | "yield"
+    )
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Keyword {
+    Alias,
+    Break,
+    Case,
+    Const,
+    ConstAssert,
+    Continue,
+    Continuing,
+    Default,
+    Diagnostic,
+    Discard,
+    Else,
+    Enable,
+    Fn,
+    For,
+    If,
+    Let,
+    Loop,
+    Override,
+    Requires,
+    Return,
+    Struct,
+    Switch,
+    Var,
+    While,
+}

--- a/wgsl-language-server/src/lexer/template_disambiguation.rs
+++ b/wgsl-language-server/src/lexer/template_disambiguation.rs
@@ -1,0 +1,210 @@
+use std::ops::Range;
+
+use super::Token;
+
+pub fn insert_template_tokens(source: &str, tokens: &mut Vec<(Token, Range<usize>)>) {
+    let templates = find_templates(source);
+
+    let is_start = |pos| templates.iter().any(|(start, _)| *start == pos);
+    let is_end = |pos| templates.iter().any(|(_, end)| *end == pos);
+
+    let mut res_tokens: Vec<(Token, Range<usize>)> = vec![];
+
+    for (token, span) in tokens.iter() {
+        if matches!(token, Token::Syntax("<<") | Token::Syntax(">>")) {
+            let ident = match token {
+                Token::Syntax("<<") => Token::TemplateArgsStart,
+                Token::Syntax(">>") => Token::TemplateArgsEnd,
+                _ => unreachable!(),
+            };
+
+            let (left, right) = (span.start, span.start + 1);
+            let (left_tok, right_tok) = (Token::Syntax("<"), Token::Syntax(">"));
+            let (left_span, right_span) = (left..(left + 1), (right..(right + 1)));
+
+            match (
+                is_end(left) || is_start(left),
+                is_end(right) || is_start(right),
+            ) {
+                (true, true) => {
+                    res_tokens.push((ident.clone(), left_span));
+                    res_tokens.push((ident.clone(), right_span));
+                    continue;
+                }
+                (true, false) => {
+                    res_tokens.push((ident.clone(), left_span));
+                    res_tokens.push((right_tok.clone(), right_span));
+                    continue;
+                }
+                (false, true) => {
+                    res_tokens.push((left_tok.clone(), left_span));
+                    res_tokens.push((ident.clone(), right_span));
+                    continue;
+                }
+                _ => {}
+            }
+        } else if is_start(span.start) {
+            res_tokens.push((Token::TemplateArgsStart, span.clone()));
+            continue;
+        } else if is_end(span.start) {
+            res_tokens.push((Token::TemplateArgsEnd, span.clone()));
+            continue;
+        }
+
+        res_tokens.push((token.clone(), span.clone()));
+    }
+
+    *tokens = res_tokens;
+}
+
+// https://www.w3.org/TR/WGSL/#template-list-discovery
+// This is required to disambiguate templates from comparison operators
+// TODO: Modify this algorithm to work on tokens
+fn find_templates(src: &str) -> Vec<(usize, usize)> {
+    struct UnclosedCandidate {
+        // Position offset in bytes
+        position: usize,
+        depth: u32,
+    }
+
+    let chars: Vec<char> = src.chars().collect();
+    let mut discovered_template_lists = vec![];
+    let mut pending: Vec<UnclosedCandidate> = vec![];
+    let mut current_position: usize = 0;
+    let mut nesting_depth: u32 = 0;
+
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+
+    let byte_position = |p| chars[0..p].iter().cloned().collect::<String>().len();
+
+    while current_position < chars.len() {
+        if in_line_comment {
+            if chars[current_position] == '\n' {
+                in_line_comment = false;
+            }
+            current_position += 1;
+            continue;
+        }
+
+        if in_block_comment {
+            if chars[current_position] == '*' && chars[current_position + 1] == '/' {
+                in_block_comment = false;
+                current_position += 2;
+                continue;
+            }
+            current_position += 1;
+            continue;
+        }
+
+        match chars[current_position] {
+            '/' => {
+                current_position += 1;
+                if chars[current_position] == '/' {
+                    in_line_comment = true;
+                    current_position += 1;
+                    continue;
+                } else if chars[current_position] == '*' {
+                    in_block_comment = true;
+                    current_position += 1;
+                    continue;
+                }
+            }
+            '<' => {
+                pending.push(UnclosedCandidate {
+                    position: current_position,
+                    depth: nesting_depth,
+                });
+                current_position += 1;
+                if chars[current_position] == '<' || chars[current_position] == '=' {
+                    pending.pop();
+                    current_position += 1;
+                    continue;
+                }
+            }
+            '>' => match pending.last() {
+                Some(unclosed) if unclosed.depth == nesting_depth => {
+                    discovered_template_lists.push((
+                        byte_position(unclosed.position),
+                        byte_position(current_position),
+                    ));
+                    pending.pop();
+                    current_position += 1;
+                    continue;
+                }
+                _ => {
+                    current_position += 1;
+                    if chars[current_position] == '=' {
+                        current_position += 1
+                    }
+                    continue;
+                }
+            },
+
+            '(' | '[' => {
+                nesting_depth += 1;
+                current_position += 1;
+                continue;
+            }
+
+            ')' | ']' => {
+                loop {
+                    pending.pop();
+                    if pending.is_empty() || pending.last().unwrap().depth < nesting_depth {
+                        break;
+                    }
+                }
+                nesting_depth = nesting_depth.saturating_sub(1);
+                current_position += 1;
+                continue;
+            }
+
+            '!' => {
+                current_position += 1;
+                if chars[current_position] == '=' {
+                    current_position += 1
+                }
+                continue;
+            }
+
+            '=' => {
+                current_position += 1;
+                if chars[current_position] != '=' {
+                    nesting_depth = 0;
+                    pending.clear();
+                }
+                current_position += 1;
+                continue;
+            }
+
+            ';' | '{' | ':' => {
+                nesting_depth = 0;
+                pending.clear();
+                current_position += 1;
+            }
+
+            '&' if chars[current_position + 1] == '&' => {
+                loop {
+                    pending.pop();
+                    if pending.is_empty() || pending.last().unwrap().depth < nesting_depth {
+                        break;
+                    }
+                }
+                current_position += 2;
+            }
+
+            '|' if chars[current_position + 1] == '|' => {
+                loop {
+                    pending.pop();
+                    if pending.is_empty() || pending.last().unwrap().depth < nesting_depth {
+                        break;
+                    }
+                }
+                current_position += 2;
+            }
+            _ => current_position += 1,
+        };
+    }
+
+    discovered_template_lists
+}

--- a/wgsl-language-server/src/lexer/test.rs
+++ b/wgsl-language-server/src/lexer/test.rs
@@ -1,0 +1,17 @@
+#[cfg(test)]
+mod comment;
+
+#[cfg(test)]
+mod ident;
+
+#[cfg(test)]
+mod keyword;
+
+#[cfg(test)]
+mod literal;
+
+#[cfg(test)]
+mod misc;
+
+#[cfg(test)]
+mod operator;

--- a/wgsl-language-server/src/lexer/test/comment.rs
+++ b/wgsl-language-server/src/lexer/test/comment.rs
@@ -1,0 +1,77 @@
+use super::super::*;
+
+#[test]
+pub fn comments_are_skipped() {
+    let source = "/* This is a comment */ const";
+    let mut lexer = Token::lexer(source);
+    assert_eq!(
+        Some(Ok(Token::Trivia("/* This is a comment */"))),
+        lexer.next(),
+        "Lexer should handle comments"
+    );
+    assert_eq!(
+        Some(Ok(Token::Keyword(Keyword::Const))),
+        lexer.next(),
+        "Lexer should find keyword after comment"
+    );
+}
+
+#[test]
+pub fn multiline_comment_basic() {
+    let source = "const /* This is a\nmultiline comment */ const";
+    let mut lexer = Token::lexer(source);
+    assert_eq!(
+        Some(Ok(Token::Keyword(Keyword::Const))),
+        lexer.next(),
+        "Lexer should find keyword before multiline comment"
+    );
+    assert_eq!(
+        Some(Ok(Token::Trivia("/* This is a\nmultiline comment */"))),
+        lexer.next(),
+        "Lexer should handle multiline comments"
+    );
+    assert_eq!(
+        Some(Ok(Token::Keyword(Keyword::Const))),
+        lexer.next(),
+        "Lexer should find keyword after multiline comment"
+    );
+}
+
+#[test]
+pub fn multiline_comment_nested() {
+    let source = "const /* outside first \n /* inside */ \n outside second */ const";
+    let mut lexer = Token::lexer(source);
+    assert_eq!(
+        Some(Ok(Token::Keyword(Keyword::Const))),
+        lexer.next(),
+        "Lexer should find keyword before multiline comment"
+    );
+    assert_eq!(
+        Some(Ok(Token::Trivia(
+            "/* outside first \n /* inside */ \n outside second */"
+        ))),
+        lexer.next(),
+        "Lexer should handle multiline comments"
+    );
+    assert_eq!(
+        Some(Ok(Token::Keyword(Keyword::Const))),
+        lexer.next(),
+        "Lexer should find keyword after multiline comment"
+    );
+}
+
+#[test]
+pub fn multiline_comment_unterminated() {
+    let source = "const /* This is an unterminated comment";
+    let mut lexer = Token::lexer(source);
+    assert_eq!(
+        Some(Ok(Token::Keyword(Keyword::Const))),
+        lexer.next(),
+        "Lexer should find keyword before unterminated comment"
+    );
+    assert_eq!(
+        Some(Err(LexError::UnterminatedComment)),
+        lexer.next(),
+        "Lexer should error on unterminated comment"
+    );
+}

--- a/wgsl-language-server/src/lexer/test/ident.rs
+++ b/wgsl-language-server/src/lexer/test/ident.rs
@@ -1,0 +1,65 @@
+use super::super::*;
+
+#[test]
+pub fn ident_with_leading_underscore_is_valid() {
+    let ident = "_validIdent";
+    let mut lexer = Token::lexer(ident);
+    assert_eq!(
+        Some(Ok(Token::Ident(ident))),
+        lexer.next(),
+        "Leading underscore should be a valid token"
+    );
+}
+
+#[test]
+pub fn ident_with_double_leading_underscore_is_invalid() {
+    let ident = "__invalidIdent";
+    let mut lexer = Token::lexer(ident);
+    assert_eq!(
+        Some(Err(LexError::InvalidIdentifier(
+            IdentError::DoubleLeadingUnderscore
+        ))),
+        lexer.next(),
+        "Double leading underscore should not be valid"
+    );
+}
+
+#[test]
+pub fn ident_with_single_underscore_is_invalid() {
+    let ident = "_";
+    let mut lexer = Token::lexer(ident);
+    assert_eq!(
+        Some(Err(LexError::InvalidIdentifier(
+            IdentError::SingleUnderscore
+        ))),
+        lexer.next(),
+        "Single underscore should not be valid ident"
+    );
+}
+
+#[test]
+pub fn ident_with_non_ascii_is_valid() {
+    // Examples taken from WGSL language specification
+    let idents = [
+        "Δέλτα",
+        "réflexion",
+        "Кызыл",
+        "𐰓𐰏𐰇",
+        "朝焼け",
+        "سلام",
+        "검정",
+        "שָׁלוֹם",
+        "गुलाबी",
+        "փիրուզ",
+    ];
+
+    for ident in idents.iter() {
+        let mut lexer = Token::lexer(ident);
+        assert_eq!(
+            Some(Ok(Token::Ident(ident))),
+            lexer.next(),
+            "Failed for {}",
+            ident
+        );
+    }
+}

--- a/wgsl-language-server/src/lexer/test/keyword.rs
+++ b/wgsl-language-server/src/lexer/test/keyword.rs
@@ -1,0 +1,53 @@
+use super::super::*;
+
+#[test]
+pub fn keyword_takes_priority() {
+    let keywords = [
+        ("alias", Keyword::Alias),
+        ("break", Keyword::Break),
+        ("case", Keyword::Case),
+        ("const", Keyword::Const),
+        ("const_assert", Keyword::ConstAssert),
+        ("continue", Keyword::Continue),
+        ("continuing", Keyword::Continuing),
+        ("default", Keyword::Default),
+        ("diagnostic", Keyword::Diagnostic),
+        ("discard", Keyword::Discard),
+        ("else", Keyword::Else),
+        ("enable", Keyword::Enable),
+        ("fn", Keyword::Fn),
+        ("for", Keyword::For),
+        ("if", Keyword::If),
+        ("let", Keyword::Let),
+        ("loop", Keyword::Loop),
+        ("override", Keyword::Override),
+        ("requires", Keyword::Requires),
+        ("return", Keyword::Return),
+        ("struct", Keyword::Struct),
+        ("switch", Keyword::Switch),
+        ("var", Keyword::Var),
+        ("while", Keyword::While),
+    ];
+    for (source, keyword) in keywords.iter() {
+        let mut lexer = Token::lexer(source);
+        assert_eq!(
+            Some(Ok(Token::Keyword(*keyword))),
+            lexer.next(),
+            "Lexer should prioritize keyword {:?} over ident",
+            keyword
+        );
+    }
+}
+
+#[test]
+pub fn reserved_words_should_be_invalid() {
+    let ident = "interface";
+    let mut lexer = Token::lexer(ident);
+    assert_eq!(
+        Some(Err(LexError::InvalidIdentifier(
+            IdentError::ReservedKeyword
+        ))),
+        lexer.next(),
+        "Reserved words should not be valid"
+    );
+}

--- a/wgsl-language-server/src/lexer/test/literal.rs
+++ b/wgsl-language-server/src/lexer/test/literal.rs
@@ -1,0 +1,95 @@
+use super::super::*;
+
+#[cfg(test)]
+mod int {
+    use super::*;
+    #[test]
+    pub fn decimal_int_literals() {
+        let literals = ["0", "0u", "0i", "1u", "123", "5346u"];
+
+        for literal in literals.iter() {
+            let mut lexer = Token::lexer(literal);
+            assert_eq!(
+                Some(Ok(Token::Integer(literal))),
+                lexer.next(),
+                "Lexer should parse integer decimal literal {:?}",
+                literal
+            );
+        }
+    }
+
+    #[test]
+    pub fn hex_int_literals() {
+        let literals = [
+            "0x0", "0x0u", "0x0i", "0x1u", "0x123", "0x5346u", "0X123u", "0x3f",
+        ];
+
+        for literal in literals.iter() {
+            let mut lexer = Token::lexer(literal);
+            assert_eq!(
+                Some(Ok(Token::Integer(literal))),
+                lexer.next(),
+                "Lexer should parse integer hex literal {:?}",
+                literal
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod bool {
+    use super::*;
+    #[test]
+    pub fn boolean_literals() {
+        let bools = [("true", true), ("false", false)];
+
+        for (source, value) in bools.iter() {
+            let mut lexer = Token::lexer(source);
+            assert_eq!(
+                Some(Ok(Token::Boolean(*value))),
+                lexer.next(),
+                "Lexer should parse boolean literal {:?}",
+                value
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod float {
+    use super::*;
+    #[test]
+    pub fn decimal_float_literals() {
+        let literals = ["0.e+4f", "01.", ".01", "12.34", ".0f", "0h", "1e-3"];
+        for literal in literals.iter() {
+            let mut lexer = Token::lexer(literal);
+            assert_eq!(
+                Some(Ok(Token::Float(literal))),
+                lexer.next(),
+                "Lexer should parse float decimal literal {:?}",
+                literal
+            );
+        }
+    }
+
+    #[test]
+    pub fn hex_float_literals() {
+        let literals = [
+            "0xa.fp+2",
+            "0x1P+4f",
+            "0X.3",
+            "0x3p+2h",
+            "0X1.fp-4",
+            "0x3.2p+2h",
+        ];
+        for literal in literals.iter() {
+            let mut lexer = Token::lexer(literal);
+            assert_eq!(
+                Some(Ok(Token::Float(literal))),
+                lexer.next(),
+                "Lexer should parse float hex literal {:?}",
+                literal
+            );
+        }
+    }
+}

--- a/wgsl-language-server/src/lexer/test/misc.rs
+++ b/wgsl-language-server/src/lexer/test/misc.rs
@@ -1,0 +1,11 @@
+use super::super::*;
+#[test]
+pub fn whitespace_is_skipped() {
+    let source = "  \t\n  const";
+    let mut lexer = Token::lexer(source);
+    assert_eq!(
+        Some(Ok(Token::Keyword(Keyword::Const))),
+        lexer.next(),
+        "Lexer should skip whitespace"
+    );
+}

--- a/wgsl-language-server/src/lexer/test/operator.rs
+++ b/wgsl-language-server/src/lexer/test/operator.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+
+#[test]
+pub fn operators_take_priority() {
+    let operators = [
+        "<<=", ">>=", "==", "!=", "<=", ">=", "&&", "||", "->", "=>", "++", "--", "+=", "-=", "*=",
+        "/=", "%=", "&=", "|=", "^=", ">>", "<<", "(", ")", "[", "]", "{", "}", ";", ".", ",", ":",
+        "&", "|", "^", "@", "=", ">", "<", "%", "/", "+", "-", "*", "~", "!",
+    ];
+
+    for op in operators.iter() {
+        let mut lexer = Token::lexer(op);
+        assert_eq!(
+            Some(Ok(Token::Syntax(op))),
+            lexer.next(),
+            "Lexer should prioritize operator {:?} over ident",
+            op
+        );
+    }
+}

--- a/wgsl-language-server/src/lib.rs
+++ b/wgsl-language-server/src/lib.rs
@@ -84,8 +84,8 @@ impl WGSLLanguageServer {
             return None;
         };
 
-        let res = self.documents.format_document(params);
-        res.map(|edits| serde_json::to_string(&edits).unwrap())
+        let edits = self.documents.format_document(params)?;
+        serde_json::to_string(&edits).ok()
     }
 
     #[wasm_bindgen(js_name = onNotification)]

--- a/wgsl-language-server/src/lib.rs
+++ b/wgsl-language-server/src/lib.rs
@@ -1,12 +1,12 @@
 mod block_ext;
 mod completions;
 mod document_tracker;
+mod lexer;
 mod parser;
 mod pretty_error;
 mod range_tools;
 mod symbol_provider;
 mod wgsl_error;
-
 
 mod macros {
     macro_rules! log {
@@ -36,7 +36,6 @@ extern "C" {
     #[wasm_bindgen(js_namespace = console, js_name = error)]
     fn console_log(s: &str);
 }
-
 
 #[wasm_bindgen]
 pub struct WGSLLanguageServer {
@@ -111,7 +110,11 @@ impl WGSLLanguageServer {
         for params in diagnostics {
             let params = &to_value(&params).unwrap();
             if let Err(e) = self.send_diagnostics_callback.call1(this, params) {
-                log!("send_diagnostics params:\n\t{:?}\n\tJS error: {:?}", params, e);
+                log!(
+                    "send_diagnostics params:\n\t{:?}\n\tJS error: {:?}",
+                    params,
+                    e
+                );
             }
         }
     }


### PR DESCRIPTION
Addresses #4

Adds support for automatic formatting of WGSL files
Formatting style is meant to closely match that of [rustfmt](https://github.com/rust-lang/rustfmt)
