### PR TITLE
[0.6.1] Formatting fixes and adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 
 - Incorrect usage of source field in LSP diagnostic
 
-## [0.3.0] 
+## [0.3.0]
 
 ### Added
 
@@ -44,7 +44,7 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 
 - [Incorrect diagnostic due to detection of entry-point outputs](https://github.com/unfinishedprogram/wgsl-analyzer/issues/1)
 
-## [0.4.0] 
+## [0.4.0]
 
 ### Changed
 
@@ -55,7 +55,7 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 
 - [#3](https://github.com/unfinishedprogram/wgsl-analyzer/issues/3) Is now fixed, since it was caused by a bug in a previous version of Naga
 
-## [0.4.1] 
+## [0.4.1]
 
 ### Changed
 
@@ -63,18 +63,18 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 - Refactor of autocompletion system
 
 
-## [0.4.2] 
+## [0.4.2]
 
 ### Fixed
 
 - Fixed incorrect error reporting locations on windows due to incorrect handling of CRLF line terminators see [issue #6](https://github.com/unfinishedprogram/wgsl-analyzer/issues/6)
 
 
-## [0.4.3] 
+## [0.4.3]
 
 ### Fixed
 
-- Fixed panic when handling auto-completion after deleting lines 
+- Fixed panic when handling auto-completion after deleting lines
 
 ### Changed
 
@@ -114,3 +114,24 @@ All notable changes to the "WGSL Language Server" extension will be documented i
 ### Changed
 
 - Removed non-existent literals from language-configuration
+
+
+## [0.6.1]
+
+### Changed
+
+- Updated rust edition to 2024
+- Added package categories for new formatting feature
+
+### Fixed
+
+- Many formatting adjustments
+  - A newline is added before attributes
+  - Properties are separated with a newline for struct declarations
+  - Whitespace between nested index accesses are removed
+  - Whitespace surrounding index accesses are removed
+  - Space between unary operations and targets has been removed
+  - Fixed unwanted newlines in for loops
+  - Removed newline within body of empty blocks
+- Fixed potential panic when parsing nested block comments
+- Massively improved formatting performance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wgsl-lang",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wgsl-lang",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "vscode-languageclient": "^8.1.0",
         "vscode-languageserver": "^8.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wgsl-lang",
   "displayName": "WGSL Language Support",
   "description": "",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "noah-labrecque",
   "repository": {
     "type": "github",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "main": "./dist/extension.js",
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Linters",
+    "Formatters"
   ],
   "keywords": [
     "wgsl",

--- a/wgsl-language-server/Cargo.toml
+++ b/wgsl-language-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgsl-language-server"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/wgsl-language-server/src/completions/builtins.rs
+++ b/wgsl-language-server/src/completions/builtins.rs
@@ -1,6 +1,6 @@
 use lsp_types::CompletionItemKind;
 
-use super::{completion_provider::new_completion_item, CompletionProvider};
+use super::{CompletionProvider, completion_provider::new_completion_item};
 pub struct BuiltinCompletions;
 
 impl CompletionProvider for BuiltinCompletions {

--- a/wgsl-language-server/src/completions/document_completions.rs
+++ b/wgsl-language-server/src/completions/document_completions.rs
@@ -2,16 +2,16 @@ use lsp_types::{CompletionItem, CompletionItemKind, Position};
 use naga::{Function, Span};
 
 use super::{
-    completion_provider::{detailed_completion_item, new_completion_item},
     CompletionProvider,
+    completion_provider::{detailed_completion_item, new_completion_item},
 };
 
 use crate::{
     completions::swizzle::SWIZZLES,
     document_tracker::TrackedDocument,
     parser::matching_bracket_index,
-    pretty_error::error_context::{type_print::TypePrintable, ModuleContext},
-    range_tools::{source_location_to_range, span_to_lsp_range, string_offset, RangeTools},
+    pretty_error::error_context::{ModuleContext, type_print::TypePrintable},
+    range_tools::{RangeTools, source_location_to_range, span_to_lsp_range, string_offset},
 };
 
 impl TrackedDocument {
@@ -203,7 +203,7 @@ impl TrackedDocument {
                     .iter()
                     .flat_map(|member| member.name.clone())
                     .map(|name| new_completion_item(name, CompletionItemKind::FIELD))
-                    .collect()
+                    .collect();
             }
         }
 

--- a/wgsl-language-server/src/completions/keywords.rs
+++ b/wgsl-language-server/src/completions/keywords.rs
@@ -1,6 +1,6 @@
 use lsp_types::CompletionItemKind;
 
-use super::{completion_provider::new_completion_item, CompletionProvider};
+use super::{CompletionProvider, completion_provider::new_completion_item};
 
 pub struct KeywordCompletions;
 

--- a/wgsl-language-server/src/completions/property_access.rs
+++ b/wgsl-language-server/src/completions/property_access.rs
@@ -1,11 +1,12 @@
-use std::sync::LazyLock;
 use lsp_types::Position;
 use naga::TypeInner;
 use regex::Regex;
+use std::sync::LazyLock;
 
 use crate::pretty_error::error_context::{FunctionContext, ModuleContext};
 
-static RE_ACCESS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(^\w+|\[[^\]]+\]|\.\w+)").unwrap());
+static RE_ACCESS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(^\w+|\[[^\]]+\]|\.\w+)").unwrap());
 
 #[derive(Debug)]
 pub enum PropertyAccess<'a> {
@@ -13,7 +14,7 @@ pub enum PropertyAccess<'a> {
     Index,
 }
 
-fn parse_property_accesses(line:&str) -> Vec<PropertyAccess> {
+fn parse_property_accesses(line: &str) -> Vec<PropertyAccess> {
     let line = line.trim();
     let mut props = vec![];
 
@@ -43,31 +44,28 @@ impl FunctionContext<'_> {
                         if let TypeInner::Struct { members, .. } = base {
                             for member in members {
                                 if member.name.as_ref().is_some_and(|it| it == name) {
-                                    current_type = Some(self.module().types[member.ty].inner.clone());
+                                    current_type =
+                                        Some(self.module().types[member.ty].inner.clone());
                                     break;
                                 }
                             }
                         }
                     } else {
-                        current_type = self.get_type_by_name(name).map(|ty|ty.inner);
+                        current_type = self.get_type_by_name(name).map(|ty| ty.inner);
                     }
                 }
-                PropertyAccess::Index => {
-                    match current_type {
-                        Some(TypeInner::Array { base, .. }|TypeInner::BindingArray { base, .. }) => {
-                            current_type = Some(self.module().types[base].inner.clone());
-                        }
-                        _ => break,
+                PropertyAccess::Index => match current_type {
+                    Some(TypeInner::Array { base, .. } | TypeInner::BindingArray { base, .. }) => {
+                        current_type = Some(self.module().types[base].inner.clone());
                     }
-                }
+                    _ => break,
+                },
             }
         }
-        
 
         current_type
     }
 }
-
 
 impl ModuleContext<'_> {
     pub fn get_proceeding_popery_access_type(
@@ -76,14 +74,11 @@ impl ModuleContext<'_> {
         function: &naga::Function,
     ) -> Option<TypeInner> {
         // TODO: Extract only the part of the line before the cursor
-        let line = self.code
-            .split('\n')
-            .nth(position.line as usize)
-            .unwrap();
+        let line = self.code.split('\n').nth(position.line as usize).unwrap();
 
         let accesses = parse_property_accesses(line);
 
-        self.function_ctx(function).evaluate_property_access_type(&accesses)
+        self.function_ctx(function)
+            .evaluate_property_access_type(&accesses)
     }
-
 }

--- a/wgsl-language-server/src/document_tracker.rs
+++ b/wgsl-language-server/src/document_tracker.rs
@@ -5,9 +5,9 @@ use lsp_types::{
     Position, PublishDiagnosticsParams, Range, TextDocumentItem, TextEdit, Uri,
 };
 use naga::{
+    Module,
     front::wgsl::ParseError,
     valid::{Capabilities, ModuleInfo, ValidationError, ValidationFlags, Validator},
-    Module,
 };
 
 use crate::{

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -48,15 +48,17 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
             (T::Syntax("("), _) => D::None,
             (_, T::Syntax(")")) => D::None,
 
+            (T::Syntax("{"), T::Syntax("}")) => D::Space,
+
             (_, T::Syntax("}")) => {
                 ctx.dedent();
                 D::Newline
             }
-            (T::Syntax(";"), _) => D::Newline,
             (T::Syntax("{"), _) => {
                 ctx.indent();
                 D::Newline
             }
+            (T::Syntax(";"), _) => D::Newline,
 
             (T::Syntax("}"), _) => {
                 if ctx.indent_level == 0 {

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -1,6 +1,6 @@
 use lsp_types::FormattingOptions;
 
-use crate::lexer::{Token, lex};
+use crate::lexer::{Keyword, Token, lex};
 
 pub enum Delimiter {
     DoubleNewline,
@@ -96,6 +96,12 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
                 } else {
                     D::Space
                 }
+            }
+
+            (_, T::Keyword(Keyword::Fn | Keyword::Var | Keyword::Const))
+                if (ctx.template_level == 0 && ctx.paren_level == 0 && ctx.bracket_level == 0) =>
+            {
+                D::Newline
             }
 
             (T::Syntax("@"), _) => D::None,

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -1,6 +1,6 @@
 use lsp_types::FormattingOptions;
 
-use crate::lexer::{lex, Token};
+use crate::lexer::{Token, lex};
 
 pub fn indent_string(options: &FormattingOptions) -> String {
     if options.insert_spaces {

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -48,8 +48,8 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
             (T::Syntax("("), _) => D::None,
             (_, T::Syntax(")")) => D::None,
 
-            (T::Syntax(";"), T::Syntax("}")) => {
-                ctx.indent_level = ctx.indent_level.saturating_sub(1);
+            (_, T::Syntax("}")) => {
+                ctx.dedent();
                 D::Newline
             }
             (T::Syntax(";"), _) => D::Newline,
@@ -57,10 +57,7 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
                 ctx.indent();
                 D::Newline
             }
-            (_, T::Syntax("}")) => {
-                ctx.dedent();
-                D::Newline
-            }
+
             (T::Syntax("}"), _) => {
                 if ctx.indent_level == 0 {
                     D::DoubleNewline

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -56,6 +56,9 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
             (T::Syntax("("), _) => D::None,
             (_, T::Syntax(")")) => D::None,
 
+            (T::Syntax("["), _) => D::None,
+            (_, T::Syntax("]")) => D::None,
+
             (T::Syntax("{"), T::Syntax("}")) => D::Space,
 
             (_, T::Syntax("}")) => {
@@ -83,6 +86,7 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
             (T::Syntax("@"), _) => D::None,
             (_, T::Syntax(";")) => D::None,
             (_, T::Syntax(",")) => D::None,
+            (T::Ident(_), T::Syntax("++")) => D::None,
             (T::Ident(_), T::Syntax(":")) => D::None,
             (T::Ident(_), T::Syntax("(")) => D::None,
             (T::Trivia(_), _) => D::Newline,

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -59,7 +59,7 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
             (T::Syntax("["), _) => D::None,
             (_, T::Syntax("]")) => D::None,
 
-            (T::Ident(_), T::Syntax("[")) => D::None,
+            (T::Ident(_) | T::Syntax("]"), T::Syntax("[")) => D::None,
             (T::Syntax("{"), T::Syntax("}")) => D::Space,
 
             (_, T::Syntax("}")) => {

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -65,7 +65,7 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
                 D::Newline
             }
             (T::Syntax(";"), _) => {
-                if ctx.inside_parenthesis() {
+                if ctx.paren_level > 0 {
                     D::Space
                 } else {
                     D::Newline
@@ -230,9 +230,5 @@ impl ASTContext<'_> {
 
     fn indentation(&self) -> String {
         self.indent_str.repeat(self.indent_level)
-    }
-
-    fn inside_parenthesis(&self) -> bool {
-        self.paren_level > 0
     }
 }

--- a/wgsl-language-server/src/fmt.rs
+++ b/wgsl-language-server/src/fmt.rs
@@ -59,6 +59,7 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
             (T::Syntax("["), _) => D::None,
             (_, T::Syntax("]")) => D::None,
 
+            (T::Ident(_), T::Syntax("[")) => D::None,
             (T::Syntax("{"), T::Syntax("}")) => D::Space,
 
             (_, T::Syntax("}")) => {
@@ -83,12 +84,16 @@ pub fn pretty_print_ast(code: &str, options: &FormattingOptions) -> Option<Strin
                     D::Newline
                 }
             }
+
+            // Unary Operators
+            (T::Syntax("!" | "~"), _) => D::None,
+
             (T::Syntax("@"), _) => D::None,
             (_, T::Syntax(";")) => D::None,
             (_, T::Syntax(",")) => D::None,
-            (T::Ident(_), T::Syntax("++")) => D::None,
+            (T::Ident(_) | T::Syntax("]"), T::Syntax("++" | "--")) => D::None,
             (T::Ident(_), T::Syntax(":")) => D::None,
-            (T::Ident(_), T::Syntax("(")) => D::None,
+            (T::Ident(_) | T::TemplateArgsEnd, T::Syntax("(")) => D::None,
             (T::Trivia(_), _) => D::Newline,
             (
                 T::Keyword(_)

--- a/wgsl-language-server/src/lexer.rs
+++ b/wgsl-language-server/src/lexer.rs
@@ -6,7 +6,7 @@ mod comment;
 mod keyword;
 mod template_disambiguation;
 mod test;
-use keyword::{parse_ident, IdentError, Keyword};
+use keyword::{IdentError, Keyword, parse_ident};
 use template_disambiguation::insert_template_tokens;
 
 use crate::log;

--- a/wgsl-language-server/src/lexer.rs
+++ b/wgsl-language-server/src/lexer.rs
@@ -6,7 +6,8 @@ mod comment;
 mod keyword;
 mod template_disambiguation;
 mod test;
-use keyword::{IdentError, Keyword, parse_ident};
+pub use keyword::Keyword;
+use keyword::{IdentError, parse_ident};
 use template_disambiguation::insert_template_tokens;
 
 use crate::log;

--- a/wgsl-language-server/src/lexer/comment.rs
+++ b/wgsl-language-server/src/lexer/comment.rs
@@ -26,15 +26,16 @@ pub fn lex_multiline_comment<'a>(lex: &mut Lexer<'a, Token<'a>>) -> Result<&'a s
             (None, Some(end)) => {
                 comment_depth -= 1;
                 pos += end + 2;
-                if comment_depth == 0 {
-                    lex.bump(pos);
-                    return Ok(lex.slice());
-                }
             }
             (None, None) => {
                 lex.bump(remainder_slice.len());
                 return Err(LexError::UnterminatedComment);
             }
+        }
+
+        if comment_depth == 0 {
+            lex.bump(pos);
+            return Ok(lex.slice());
         }
     }
 }

--- a/wgsl-language-server/src/lib.rs
+++ b/wgsl-language-server/src/lib.rs
@@ -36,6 +36,9 @@ use wasm_bindgen::prelude::*;
 extern "C" {
     #[wasm_bindgen(js_namespace = console, js_name = error)]
     fn console_log(s: &str);
+
+    #[wasm_bindgen(js_namespace = performance, js_name = now)]
+    fn performance_now() -> usize;
 }
 
 #[wasm_bindgen]

--- a/wgsl-language-server/src/pretty_error/error_context.rs
+++ b/wgsl-language-server/src/pretty_error/error_context.rs
@@ -7,12 +7,12 @@ use crate::block_ext::BlockExt;
 use as_type::AsType;
 use codespan_reporting::diagnostic::Diagnostic;
 use naga::{
-    valid::{CallError, ExpressionError, FunctionError, ValidationError},
     Expression, Function, Handle, Module, Statement, WithSpan,
+    valid::{CallError, ExpressionError, FunctionError, ValidationError},
 };
 use type_print::TypePrintable;
 
-use super::label_tools::{label_primary, label_secondary, LabelAppend};
+use super::label_tools::{LabelAppend, label_primary, label_secondary};
 
 pub struct ModuleContext<'a> {
     pub module: &'a Module,

--- a/wgsl-language-server/src/pretty_error/error_context/ident_query.rs
+++ b/wgsl-language-server/src/pretty_error/error_context/ident_query.rs
@@ -1,6 +1,6 @@
 use naga::{Constant, Expression, GlobalVariable, Handle, LocalVariable, Type};
 
-use super::{as_type::AsType, FunctionContext, ModuleContext};
+use super::{FunctionContext, ModuleContext, as_type::AsType};
 
 pub enum GlobalIdentQueryResult {
     GlobalVariable(Handle<GlobalVariable>),

--- a/wgsl-language-server/src/wgsl_error.rs
+++ b/wgsl-language-server/src/wgsl_error.rs
@@ -1,6 +1,6 @@
 use codespan_reporting::diagnostic::{Diagnostic, LabelStyle};
 use lsp_types::{DiagnosticRelatedInformation, Uri};
-use naga::{front::wgsl::ParseError, SourceLocation};
+use naga::{SourceLocation, front::wgsl::ParseError};
 
 use crate::{
     pretty_error::error_context::ModuleContext,


### PR DESCRIPTION
### Changed

- Updated rust edition to 2024
- Added package categories for new formatting feature

### Fixed

- Many formatting adjustments
  - A newline is added before attributes
  - Properties are separated with a newline for struct declarations
  - Whitespace between nested index accesses are removed
  - Whitespace surrounding index accesses are removed
  - Space between unary operations and targets has been removed
  - Fixed unwanted newlines in for loops
  - Removed newline within body of empty blocks
- Fixed potential panic when parsing nested block comments
- Massively improved formatting performance
